### PR TITLE
Fixed issue where we could not inherit a class not defined in __all__.

### DIFF
--- a/semterm/agent/MrklAgent.py
+++ b/semterm/agent/MrklAgent.py
@@ -1,10 +1,14 @@
+import os
+
 from langchain.agents import load_tools
 from langchain.chat_models import ChatOpenAI
 from langchain.memory import ConversationEntityMemory
 
+from semterm.agent.TerminalAgentPrompt import PREFIX
 from semterm.config.Config import Config
 from semterm.agent.TerminalAgent import TerminalAgent
 from semterm.agent.TerminalAgentExecutor import TerminalAgentExecutor
+from semterm.terminal.TerminalOutputParser import TerminalOutputParser
 from semterm.terminal.TerminalTool import TerminalTool
 from semterm.terminal.SemanticTerminalManager import SemanticTerminalManager
 from semterm.langchain_extensions.tools import MistakeTool
@@ -46,7 +50,12 @@ class MrklAgent:
 
     def initialize_agent(self):
         return TerminalAgent.from_llm_and_tools(
-            self.llm, self.tools, memory=self.memory, verbose=self.verbose
+            self.llm,
+            self.tools,
+            memory=self.memory,
+            system_message=PREFIX.format(current_directory=os.getcwd()),
+            output_parser=TerminalOutputParser(),
+            verbose=self.verbose,
         )
 
     def initialize_executor(self):

--- a/semterm/agent/TerminalAgent.py
+++ b/semterm/agent/TerminalAgent.py
@@ -4,10 +4,8 @@ from typing import Sequence, Optional, List, Tuple, Any
 from langchain import BasePromptTemplate
 from langchain.agents import (
     ConversationalChatAgent,
-    Agent,
     AgentOutputParser,
 )
-from langchain.callbacks import BaseCallbackManager
 from langchain.tools import BaseTool
 from pydantic import Field
 
@@ -21,8 +19,6 @@ from langchain.schema import (
     BaseOutputParser,
     BaseMessage,
     AIMessage,
-    HumanMessage,
-    BaseLanguageModel,
     SystemMessage,
 )
 from semterm.terminal.TerminalOutputParser import TerminalOutputParser
@@ -30,10 +26,6 @@ from semterm.terminal.TerminalOutputParser import TerminalOutputParser
 
 class TerminalAgent(ConversationalChatAgent, ABC):
     output_parser: AgentOutputParser = Field(default_factory=TerminalOutputParser)
-
-    @classmethod
-    def _get_default_output_parser(cls, **kwargs: Any) -> AgentOutputParser:
-        return TerminalOutputParser()
 
     @classmethod
     def create_prompt(
@@ -70,26 +62,3 @@ class TerminalAgent(ConversationalChatAgent, ABC):
             )
             thoughts.append(system_message)
         return thoughts
-
-    @classmethod
-    def from_llm_and_tools(
-        cls,
-        llm: BaseLanguageModel,
-        tools: Sequence[BaseTool],
-        callback_manager: Optional[BaseCallbackManager] = None,
-        output_parser: Optional[AgentOutputParser] = None,
-        system_message: str = PREFIX.format(current_directory=os.getcwd()),
-        human_message: str = SUFFIX,
-        input_variables: Optional[List[str]] = None,
-        **kwargs: Any,
-    ) -> Agent:
-        return super().from_llm_and_tools(
-            llm=llm,
-            tools=tools,
-            callback_manager=callback_manager,
-            output_parser=output_parser or cls._get_default_output_parser(),
-            system_message=system_message,
-            human_message=human_message,
-            input_variables=input_variables,
-            **kwargs,
-        )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="semterm",
-    version="0.2.1",
+    version="0.2.2",
     description="The Semantic Terminal",
     long_description="The Semantic Terminal",
     author="Lambrou",


### PR DESCRIPTION
fixed the following error:
```
ImportError: cannot import name 'BaseCallbackManager' from 'langchain.callbacks' (/home/alex/testest/test/lib/python3.9/site-packages/langchain/callbacks/__init__.py)
```